### PR TITLE
Run covr monthly.

### DIFF
--- a/.github/workflows/covr-main.yml
+++ b/.github/workflows/covr-main.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches: [main, master]
   workflow_dispatch:
+  schedule:
+    - cron: '0 13 1 * *'
 
 name: covr-main
 


### PR DESCRIPTION
Note: This will throw an error until we get covrpage working properly on this repo, but it feels like the right place to put a monthly check.

The monthly check will confirm that the API is working as expected for this package, and will regenerate the test messages on the test slack.